### PR TITLE
add error button

### DIFF
--- a/app/controllers/demo_controller.rb
+++ b/app/controllers/demo_controller.rb
@@ -4,4 +4,8 @@ class DemoController < ApplicationController
 
   def show
   end
+
+  def error
+    DoesntExist.do_something
+  end
 end

--- a/app/views/demo/index.html.erb
+++ b/app/views/demo/index.html.erb
@@ -6,9 +6,18 @@
 				<h2 class="text-3xl md:text-5xl leading-relaxed md:leading-snug mb-2">❤️ New Relic
 				</h2>
 				<p class="text-sm md:text-base text-gray-50 mb-4">Add New Relic monitoring to your Rails 7 app deployed on Render</p>
-				<a href="/demo/show"
-					class="bg-transparent hover:bg-yellow-300 text-yellow-300 hover:text-black rounded shadow hover:shadow-lg py-2 px-4 border border-yellow-300 hover:border-transparent">
-					Get Started</a>
+				<a 
+					href="/demo/show"
+					class="bg-transparent hover:bg-yellow-300 text-yellow-300 hover:text-black rounded shadow hover:shadow-lg py-2 px-4 border border-yellow-300 hover:border-transparent"
+				>
+					Get Started
+				</a>
+				<a 
+				href="/demo/error"
+				class="mt-5 bg-transparent hover:bg-red-600 text-red-600 hover:text-black rounded shadow hover:shadow-lg py-2 px-4 border border-red-600 hover:border-transparent"
+			>
+				Make an Error
+			</a>
 			</div>
 			<div class="p-8 mt-12 mb-6 md:mb-0 md:mt-0 ml-0 md:ml-12 lg:w-2/3  justify-center">
 				<div class="h-48 flex flex-wrap content-center">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,4 +5,6 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   root "demo#index"
+
+  get "/demo/error", to: "demo#error"
 end


### PR DESCRIPTION
Add an error button to the main page that will cause the app to intentionally do something wrong. Useful in simulating error tracing in New Relic.